### PR TITLE
Release v0.9.0: r{char} replace command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-05-29
+
 ### Added
 
 - `r{char}` replaces the character under the cursor. Supports counts: `3ra` replaces 3 characters with `a`.
@@ -204,7 +206,8 @@ First release. Modal editing for the OpenCode prompt.
 
 > `g` fires immediately as buffer-home instead of waiting for `gg`. The `yy` line tracker drifts on clicks and arrow keys. Visual mode and text objects aren't feasible without cursor position access.
 
-[Unreleased]: https://github.com/oribarilan/vimcode/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/oribarilan/vimcode/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/oribarilan/vimcode/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/oribarilan/vimcode/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/oribarilan/vimcode/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/oribarilan/vimcode/compare/v0.6.0...v0.6.1

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add to your `tui.json` (or `.opencode/tui.json`):
 
 ```json
 {
-  "plugin": ["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.8.0"]
+  "plugin": ["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.9.0"]
 }
 ```
 
@@ -38,7 +38,7 @@ To pass options, use the tuple form in `tui.json`:
 
 ```json
 {
-  "plugin": [["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.8.0", { "updateCheck": false }]]
+  "plugin": [["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.9.0", { "updateCheck": false }]]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimcode",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Vim keybindings for the OpenCode prompt",
   "author": "Ori Bar-ilan",
   "license": "MIT",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 // Keep in sync with package.json on each release.
-export const VERSION = "0.8.0";
+export const VERSION = "0.9.0";
 
 // GitHub API returns fresh content immediately; raw.githubusercontent.com
 // is CDN-cached for up to 5 minutes which delays update detection.


### PR DESCRIPTION
### Added

- `r{char}` replaces the character under the cursor. Supports counts: `3ra` replaces 3 characters with `a`.