### PR TITLE
feat: :q/:quit/:wq quit from the command palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ### Added
 
+- `:q`, `:quit`, and `:wq` quit OpenCode from the command palette ([#19](https://github.com/oribarilan/vimcode/issues/19)). Since `:` already opens the palette, typing `:q` and pressing Enter exits the app.
 - `Ctrl+O` in insert mode — run one normal-mode command, then return to insert. Motions, operators, counts, and `r{char}` all work.
 - `leader` plugin option — lets you use space (or any key) as leader without breaking insert mode. Spaces type normally while editing, and leader sequences like `space l` still work in normal mode ([#21](https://github.com/oribarilan/vimcode/issues/21)).
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ All normal-mode motions work for extending the selection: `h` `j` `k` `l` `w` `b
 | `Ctrl+r` | Redo |
 | `p` | Paste from yank register |
 | `:` | Command palette |
+| `:q` `:quit` `:wq` | Quit OpenCode (via command palette) |
 | `/` | Jump to message (session timeline) |
 | `[` `]` | Scroll conversation half-page up/down |
 | `{` `}` | Jump to previous/next message |

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,19 @@ const plugin: TuiPluginModule = {
       checkForUpdate((opts) => api.ui?.toast?.(opts), api.kv);
     }
 
+    // Register vim ex-commands in the command palette so that
+    // :q, :quit, and :wq work as expected.
+    const quit = {
+      category: "Vim",
+      description: "Exit OpenCode",
+      onSelect: () => setTimeout(() => api.keymap.dispatchCommand("app.exit"), 0),
+    };
+    api.command?.register?.(() => [
+      { ...quit, title: "q", value: "vimcode.q" },
+      { ...quit, title: "quit", value: "vimcode.quit" },
+      { ...quit, title: "wq", value: "vimcode.wq" },
+    ]);
+
     api.keymap.intercept(
       "key",
       (ctx) => {


### PR DESCRIPTION
Registers `q`, `quit`, and `wq` as command palette entries that exit OpenCode. Since `:` already opens the palette, typing `:q` and pressing Enter quits the app — matching vim muscle memory.

Uses `api.command.register()` to add the commands under a "Vim" category. The `onSelect` handler dispatches `app.exit` via `setTimeout` (same pattern all other dispatches use).

Closes #19