### PR TITLE
Release v0.11.0: :q to quit, Ctrl+O one-shot normal, leader key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [0.11.0] — 2026-06-08
+
 ### Added
 
 - `:q`, `:quit`, and `:wq` quit OpenCode from the command palette ([#19](https://github.com/oribarilan/vimcode/issues/19)). Since `:` already opens the palette, typing `:q` and pressing Enter exits the app.
@@ -229,7 +231,8 @@ First release. Modal editing for the OpenCode prompt.
 
 > `g` fires immediately as buffer-home instead of waiting for `gg`. The `yy` line tracker drifts on clicks and arrow keys. Visual mode and text objects aren't feasible without cursor position access.
 
-[Unreleased]: https://github.com/oribarilan/vimcode/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/oribarilan/vimcode/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/oribarilan/vimcode/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/oribarilan/vimcode/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/oribarilan/vimcode/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/oribarilan/vimcode/compare/v0.7.0...v0.8.0

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add to your `tui.json` (or `.opencode/tui.json`):
 
 ```json
 {
-  "plugin": ["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.10.0"]
+  "plugin": ["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.11.0"]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimcode",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Vim keybindings for the OpenCode prompt",
   "author": "Ori Bar-ilan",
   "license": "MIT",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 // Keep in sync with package.json on each release.
-export const VERSION = "0.10.0";
+export const VERSION = "0.11.0";
 
 // GitHub API returns fresh content immediately; raw.githubusercontent.com
 // is CDN-cached for up to 5 minutes which delays update detection.


### PR DESCRIPTION
- `:q`, `:quit`, `:wq` quit OpenCode from the command palette (#19)
- `Ctrl+O` one-shot normal mode from insert
- `leader` plugin option for space-as-leader (#21)