### PR TITLE
Release v0.12.1: fix distributed install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ vimcode is a TUI plugin for [OpenCode](https://opencode.ai). Before working on i
 - `dispatchCommand()` from inside a `key:before` intercept doesn't work for cursor movement. Wrap in `setTimeout(..., 0)` to break out of the intercept stack.
 - `registerLayer` with `activeWhen` using SolidJS signals requires `reactiveMatcherFromSignal` from `@opentui/keymap/solid`. Plain `() => signal()` doesn't trigger re-evaluation. We chose intercepts instead of layers to avoid this.
 - **SolidJS imports work in distributed plugins** as of mid-2026. The plugin uses top-level `import { createSignal } from "solid-js"` and `@jsxImportSource @opentui/solid`. This requires `"type": "module"` in package.json and `solid-js`/`@opentui/solid`/`@opentui/core` as peer dependencies. Tests need a preload (`test/preload.ts`) to mock the JSX runtime since it's only available inside the OpenCode host.
+- **Do NOT add `solid-js`, `@opentui/solid`, or `@opentui/core` as dependencies or peerDependencies.** If they're in `package.json`, Bun installs them into the plugin's `node_modules/`, and the local `.d.ts` stubs shadow the host's runtime module intercepts. The host provides these at runtime via `ensureRuntimePluginSupport`. Keep them only in `devDependencies` (via `@opencode-ai/plugin` which pulls them in for type-checking).
 
 ### Editor widget API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [0.12.1] — 2026-06-08
+
+### Fixed
+
+- Plugin failed to load when installed via git URL. Peer dependencies (`solid-js`, `@opentui/solid`, `@opentui/core`) were getting installed into the plugin's `node_modules/`, and their `.d.ts` stubs shadowed the host's runtime modules. Removed peer deps — the host provides these at runtime.
+
 ## [0.12.0] — 2026-06-08
 
 ### Added
@@ -242,7 +248,8 @@ First release. Modal editing for the OpenCode prompt.
 
 > `g` fires immediately as buffer-home instead of waiting for `gg`. The `yy` line tracker drifts on clicks and arrow keys. Visual mode and text objects aren't feasible without cursor position access.
 
-[Unreleased]: https://github.com/oribarilan/vimcode/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/oribarilan/vimcode/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/oribarilan/vimcode/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/oribarilan/vimcode/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/oribarilan/vimcode/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/oribarilan/vimcode/compare/v0.9.0...v0.10.0

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add to your `tui.json` (or `.opencode/tui.json`):
 
 ```json
 {
-  "plugin": ["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.12.0"]
+  "plugin": ["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.12.1"]
 }
 ```
 
@@ -40,7 +40,7 @@ To pass options, use the tuple form in `tui.json`:
 
 ```json
 {
-  "plugin": [["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.12.0", { "updateCheck": false }]]
+  "plugin": [["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.12.1", { "updateCheck": false }]]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimcode",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Vim keybindings for the OpenCode prompt",
   "author": "Ori Bar-ilan",
   "license": "MIT",
@@ -31,11 +31,5 @@
     "@biomejs/biome": "2.4.15",
     "@opencode-ai/plugin": "^1.15.4",
     "tsx": "^4.22.1"
-  },
-  "peerDependencies": {
-    "@opencode-ai/plugin": "*",
-    "@opentui/core": "*",
-    "@opentui/solid": "*",
-    "solid-js": "*"
   }
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 // Keep in sync with package.json on each release.
-export const VERSION = "0.12.0";
+export const VERSION = "0.12.1";
 
 // GitHub API returns fresh content immediately; raw.githubusercontent.com
 // is CDN-cached for up to 5 minutes which delays update detection.


### PR DESCRIPTION
v0.12.0 broke when installed via git URL. Bun resolved `@opentui/solid/jsx-runtime` to the local `.d.ts` stub instead of the host's runtime module because the peer deps got installed into the plugin's `node_modules/`.

Removes `solid-js`, `@opentui/solid`, and `@opentui/core` from peer deps. The host provides them at runtime.