### PR TITLE
Release v0.14.0: /vim toggle and leader key fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [0.14.0] — 2026-06-13
+
 ### Added
 
 - `/vim` toggle command to disable/enable vim mode. Persisted across restarts.
@@ -277,7 +279,8 @@ First release. Modal editing for the OpenCode prompt.
 
 > `g` fires immediately as buffer-home instead of waiting for `gg`. The `yy` line tracker drifts on clicks and arrow keys. Visual mode and text objects aren't feasible without cursor position access.
 
-[Unreleased]: https://github.com/oribarilan/vimcode/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/oribarilan/vimcode/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/oribarilan/vimcode/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/oribarilan/vimcode/compare/v0.12.2...v0.13.0
 [0.12.2]: https://github.com/oribarilan/vimcode/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/oribarilan/vimcode/compare/v0.12.0...v0.12.1

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add to your `tui.json` (or `.opencode/tui.json`):
 
 ```json
 {
-  "plugin": ["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.13.0"]
+  "plugin": ["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.14.0"]
 }
 ```
 
@@ -40,7 +40,7 @@ To pass options, use the tuple form in `tui.json`:
 
 ```json
 {
-  "plugin": [["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.12.2", { "updateCheck": false }]]
+  "plugin": [["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.14.0", { "updateCheck": false }]]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimcode",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Vim keybindings for the OpenCode prompt",
   "author": "Ori Bar-ilan",
   "license": "MIT",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 // Keep in sync with package.json on each release.
-export const VERSION = "0.13.0";
+export const VERSION = "0.14.0";
 
 // GitHub API returns fresh content immediately; raw.githubusercontent.com
 // is CDN-cached for up to 5 minutes which delays update detection.


### PR DESCRIPTION
## [0.14.0] — 2026-06-13

### Added

- `/vim` toggle command to disable/enable vim mode. Persisted across restarts.
- Startup toast when vim is disabled so users know why keybindings aren't active.

### Fixed

- Leader key now works with modifier-based configurations like the default `ctrl+x`. Previously, `parseLeaderKey` expected vim-style `C-x` notation but OpenCode's keybinds API returns `ctrl+x` format, so the leader key was silently broken for any config with modifiers.
- Leader detection supports all OpenCode modifier aliases (`control`, `alt`, `option`, `super`) and multiple leader bindings.
- Optional chaining on `api.kv.set` to avoid crashes on older OpenCode versions.
- Escape/Enter no longer intercepted when vim is disabled.
- Toggling vim off resets mode and clears pending state.
- `:vim` palette title uses `:` prefix, consistent with `:q`/`:quit`/`:wq`.