### PR TITLE
fix: use wl-copy for clipboard on Wayland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+### Fixed
+
+- Clipboard now uses `wl-copy` on Wayland instead of `xclip`, which doesn't work there.
+
 ## [0.14.0] — 2026-06-13
 
 ### Added

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -13,7 +13,7 @@ export function writeClipboard(text: string): void {
 function clipboardCmd(): [string, string[]] {
   if (process.platform === "darwin") return ["pbcopy", []];
   if (process.platform === "win32") return ["clip.exe", []];
-  // Linux: xclip is the most common. xsel and wl-copy also exist
-  // but async fallback chains add complexity for marginal gain.
+  if (process.env.WAYLAND_DISPLAY) return ["wl-copy", []];
+  // X11 fallback
   return ["xclip", ["-selection", "clipboard"]];
 }


### PR DESCRIPTION
Detect Wayland via `WAYLAND_DISPLAY` and use `wl-copy` instead of `xclip`, which doesn't work on Wayland.

Closes #31