### PR TITLE
Release v0.15.1: fix subagent permission dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [0.15.1] — 2026-06-23
+
 ### Fixed
 
-- Enter/Escape now work on subagent permission dialogs instead of being consumed by vimcome ([#47](https://github.com/oribarilan/vimcode/issues/47)).
+- Enter/Escape now work on subagent permission dialogs instead of being consumed by vim ([#47](https://github.com/oribarilan/vimcode/issues/47)).
 
 ## [0.15.0] — 2026-06-16
 
@@ -293,7 +295,8 @@ First release. Modal editing for the OpenCode prompt.
 
 > `g` fires immediately as buffer-home instead of waiting for `gg`. The `yy` line tracker drifts on clicks and arrow keys. Visual mode and text objects aren't feasible without cursor position access.
 
-[Unreleased]: https://github.com/oribarilan/vimcode/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/oribarilan/vimcode/compare/v0.15.1...HEAD
+[0.15.1]: https://github.com/oribarilan/vimcode/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/oribarilan/vimcode/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/oribarilan/vimcode/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/oribarilan/vimcode/compare/v0.12.2...v0.13.0

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add to your `tui.json` (or `.opencode/tui.json`):
 
 ```json
 {
-  "plugin": ["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.15.0"]
+  "plugin": ["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.15.1"]
 }
 ```
 
@@ -40,7 +40,7 @@ To pass options, use the tuple form in `tui.json`:
 
 ```json
 {
-  "plugin": [["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.15.0", { "updateCheck": false }]]
+  "plugin": [["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.15.1", { "updateCheck": false }]]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimcode",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Vim keybindings for the OpenCode prompt",
   "author": "Ori Bar-ilan",
   "license": "MIT",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 // Keep in sync with package.json on each release.
-export const VERSION = "0.15.0";
+export const VERSION = "0.15.1";
 
 // GitHub API returns fresh content immediately; raw.githubusercontent.com
 // is CDN-cached for up to 5 minutes which delays update detection.


### PR DESCRIPTION
Bump to v0.15.1. Single bug fix: Enter/Escape now work on permission dialogs from subagent sessions (#47).