### PR TITLE
Release v0.16.0: :w and :write send the prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [0.16.0] — 2026-08-31
+
 ### Added
 
 - `:w` and `:write` now send the prompt instead of autocompleting to `:wq` and quitting OpenCode. Sessions auto-persist, so the natural mapping for vim users' reflexive "save" is to submit the current prompt. `:wq` still quits.
@@ -309,7 +311,8 @@ First release. Modal editing for the OpenCode prompt.
 
 > `g` fires immediately as buffer-home instead of waiting for `gg`. The `yy` line tracker drifts on clicks and arrow keys. Visual mode and text objects aren't feasible without cursor position access.
 
-[Unreleased]: https://github.com/oribarilan/vimcode/compare/v0.15.3...HEAD
+[Unreleased]: https://github.com/oribarilan/vimcode/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/oribarilan/vimcode/compare/v0.15.3...v0.16.0
 [0.15.3]: https://github.com/oribarilan/vimcode/compare/v0.15.2...v0.15.3
 [0.15.2]: https://github.com/oribarilan/vimcode/compare/v0.15.1...v0.15.2
 [0.15.1]: https://github.com/oribarilan/vimcode/compare/v0.15.0...v0.15.1

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add to your `tui.json` (or `.opencode/tui.json`):
 
 ```json
 {
-  "plugin": ["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.15.3"]
+  "plugin": ["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.16.0"]
 }
 ```
 
@@ -40,7 +40,7 @@ To pass options, use the tuple form in `tui.json`:
 
 ```json
 {
-  "plugin": [["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.15.3", { "updateCheck": false }]]
+  "plugin": [["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.16.0", { "updateCheck": false }]]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimcode",
-  "version": "0.15.3",
+  "version": "0.16.0",
   "description": "Vim keybindings for the OpenCode prompt",
   "author": "Ori Bar-ilan",
   "license": "MIT",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 // Keep in sync with package.json on each release.
-export const VERSION = "0.15.3";
+export const VERSION = "0.16.0";
 
 // GitHub API returns fresh content immediately; raw.githubusercontent.com
 // is CDN-cached for up to 5 minutes which delays update detection.


### PR DESCRIPTION
Release v0.16.0. Cuts the `:w`/`:write` feature already on `main`, giving a clean baseline before the vim-engine redesign lands.

### Added

- `:w` and `:write` now send the prompt instead of autocompleting to `:wq` and quitting OpenCode. Sessions auto-persist, so the natural mapping for vim users' reflexive "save" is to submit the current prompt. `:wq` still quits.

### Release checklist

- Version bumped in `package.json` and `src/version.ts` to 0.16.0
- CHANGELOG `[Unreleased]` moved to `## [0.16.0]` with compare links updated
- README version tags bumped (install snippet + config example)
- `just check` passes locally: lint clean, 184 tests, 0 fail

After CI passes and this squash-merges, tag with `git tag v0.16.0 && git push origin v0.16.0` and create the GitHub release.