### PR TITLE
Release v0.17.0: redesign the vim engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [0.17.0] — 2026-09-02
+
 ### Changed
 
 - Redesigned the vim engine into a modular architecture for easier maintenance and future keybindings. No change to existing keybindings or behavior.
@@ -319,7 +321,8 @@ First release. Modal editing for the OpenCode prompt.
 
 > `g` fires immediately as buffer-home instead of waiting for `gg`. The `yy` line tracker drifts on clicks and arrow keys. Visual mode and text objects aren't feasible without cursor position access.
 
-[Unreleased]: https://github.com/oribarilan/vimcode/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/oribarilan/vimcode/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/oribarilan/vimcode/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/oribarilan/vimcode/compare/v0.15.3...v0.16.0
 [0.15.3]: https://github.com/oribarilan/vimcode/compare/v0.15.2...v0.15.3
 [0.15.2]: https://github.com/oribarilan/vimcode/compare/v0.15.1...v0.15.2

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add to your `tui.json` (or `.opencode/tui.json`):
 
 ```json
 {
-  "plugin": ["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.16.0"]
+  "plugin": ["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.17.0"]
 }
 ```
 
@@ -40,7 +40,7 @@ To pass options, use the tuple form in `tui.json`:
 
 ```json
 {
-  "plugin": [["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.16.0", { "updateCheck": false }]]
+  "plugin": [["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.17.0", { "updateCheck": false }]]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimcode",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Vim keybindings for the OpenCode prompt",
   "author": "Ori Bar-ilan",
   "license": "MIT",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 // Keep in sync with package.json on each release.
-export const VERSION = "0.16.0";
+export const VERSION = "0.17.0";
 
 // GitHub API returns fresh content immediately; raw.githubusercontent.com
 // is CDN-cached for up to 5 minutes which delays update detection.


### PR DESCRIPTION
Release v0.17.0. Redesigns the vim engine into a modular architecture; no change to keybindings or behavior.

### Changed

- Redesigned the vim engine into a modular architecture for easier maintenance and future keybindings. No change to existing keybindings or behavior.

### Fixed

- `dgg` and `drx` no longer leave a stray operator that affected the next keypress.

### Release checklist

- Version bumped in `package.json` and `src/version.ts` to 0.17.0
- CHANGELOG `[Unreleased]` moved to `## [0.17.0]` with compare links updated
- README version tags bumped (install snippet + config example)
- `just check` passes: lint clean, 209 tests, 0 fail

After CI passes and this squash-merges, tag `v0.17.0` and create the GitHub release.