### PR TITLE
Release v0.17.1: arrow keys pass through in normal and visual mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [0.17.1] — 2026-09-02
+
 ### Fixed
 
 - Arrow keys no longer get swallowed in normal and visual mode. They pass through to OpenCode, so you can exit the subagent view (and use other native navigation) without first switching to insert mode ([#63](https://github.com/oribarilan/vimcode/issues/63)).
@@ -325,7 +327,8 @@ First release. Modal editing for the OpenCode prompt.
 
 > `g` fires immediately as buffer-home instead of waiting for `gg`. The `yy` line tracker drifts on clicks and arrow keys. Visual mode and text objects aren't feasible without cursor position access.
 
-[Unreleased]: https://github.com/oribarilan/vimcode/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/oribarilan/vimcode/compare/v0.17.1...HEAD
+[0.17.1]: https://github.com/oribarilan/vimcode/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/oribarilan/vimcode/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/oribarilan/vimcode/compare/v0.15.3...v0.16.0
 [0.15.3]: https://github.com/oribarilan/vimcode/compare/v0.15.2...v0.15.3

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add to your `tui.json` (or `.opencode/tui.json`):
 
 ```json
 {
-  "plugin": ["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.17.0"]
+  "plugin": ["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.17.1"]
 }
 ```
 
@@ -40,7 +40,7 @@ To pass options, use the tuple form in `tui.json`:
 
 ```json
 {
-  "plugin": [["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.17.0", { "updateCheck": false }]]
+  "plugin": [["vimcode@git+https://github.com/oribarilan/vimcode.git#v0.17.1", { "updateCheck": false }]]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimcode",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Vim keybindings for the OpenCode prompt",
   "author": "Ori Bar-ilan",
   "license": "MIT",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 // Keep in sync with package.json on each release.
-export const VERSION = "0.17.0";
+export const VERSION = "0.17.1";
 
 // GitHub API returns fresh content immediately; raw.githubusercontent.com
 // is CDN-cached for up to 5 minutes which delays update detection.


### PR DESCRIPTION
Patch release for the #63 fix (already merged via #66).

### Fixed

- Arrow keys no longer get swallowed in normal and visual mode. They pass through to OpenCode, so you can exit the subagent view (and use other native navigation) without first switching to insert mode ([#63](https://github.com/oribarilan/vimcode/issues/63)).

### Release checklist

- [x] Moved `[Unreleased]` into `## [0.17.1]` and updated CHANGELOG link refs
- [x] Bumped `package.json` to 0.17.1
- [x] Bumped `VERSION` in `src/version.ts` to match
- [x] Updated README install/config version tags to v0.17.1
- [x] `just check` green (222 tests)

Tag `v0.17.1` and the GitHub release follow after this merges.